### PR TITLE
Use package.json for plug-in information

### DIFF
--- a/index.es6.js
+++ b/index.es6.js
@@ -41,6 +41,5 @@ exports.register = (server, options, next) => {
 };
 
 exports.register.attributes = {
-  name: 'memshaw',
-  version: '0.0.1',
+  pkg: require('./package.json')
 };

--- a/index.js
+++ b/index.js
@@ -57,6 +57,5 @@ exports.register = function (server, options, next) {
 };
 
 exports.register.attributes = {
-  name: 'memshaw',
-  version: '0.1.3'
+  pkg: require('./package.json')
 };


### PR DESCRIPTION
You can use the package name and version from `package.json` directly, so you don't have to maintain them in two places.
